### PR TITLE
Remove -fllvm flag from example ghc-options

### DIFF
--- a/open-union.cabal
+++ b/open-union.cabal
@@ -90,7 +90,7 @@ library
 executable example
     hs-source-dirs:   .
     main-is: example.hs
-    ghc-options: -Wall -fllvm -O2
+    ghc-options: -Wall -O2
     build-depends : base == 4.*
                   , open-union
 


### PR DESCRIPTION
Otherwise this package doesn't build without LLVM installed.
