### PR TITLE
some improvements

### DIFF
--- a/Data/OpenUnion.hs
+++ b/Data/OpenUnion.hs
@@ -1,8 +1,6 @@
 -- | Flexible, type-safe open unions.
 module Data.OpenUnion
     ( Union
-    , (:<)
-    , (:\)
     , (@>)
     , liftUnion
     , reUnion

--- a/Data/OpenUnion/Internal.hs
+++ b/Data/OpenUnion/Internal.hs
@@ -22,7 +22,7 @@ module Data.OpenUnion.Internal
     ) where
 
 import Data.Dynamic
-import TypeFun.Data.List
+import TypeFun.Data.List (SubList, Elem, Delete)
 
 -- | The @Union@ type - the phantom parameter @s@ is a list of types
 -- denoting what this @Union@ might contain.

--- a/Data/OpenUnion/Internal.hs
+++ b/Data/OpenUnion/Internal.hs
@@ -12,8 +12,6 @@
 {-# LANGUAGE UndecidableInstances #-}
 module Data.OpenUnion.Internal
     ( Union (..)
-    , (:<)
-    , (:\)
     , (@>)
     , (@!>)
     , liftUnion
@@ -23,8 +21,7 @@ module Data.OpenUnion.Internal
     ) where
 
 import Data.Dynamic
-import Data.Type.Bool
-import GHC.Exts
+import TypeFun.Data.List
 
 -- | The @Union@ type - the phantom parameter @s@ is a list of types
 -- denoting what this @Union@ might contain.
@@ -34,71 +31,37 @@ newtype Union (s :: [*]) = Union Dynamic
 -- general note: try to keep from re-constructing Unions if an existing one
 -- can just be type-coerced.
 
--- | Remove a type from anywhere in the list.
-type family s :\ a where
-    '[] :\ a = '[]
-    (a ': s) :\ a = s :\ a
-    (a' ': s) :\ a = a' ': (s :\ a)
-
--- | There exists a @s :< s'@ instance if every type in the list @s@
--- can be lifted to @s'@.
--- class (:<) (s :: [*]) (s' :: [*])
-
-type (:<) s s' =
-  ( SubList s s'
-  , AllSatisfy Typeable s
-  , AllSatisfy Typeable s')
-
-class NotASubListOf s s'
-
-type SubList s s' = If (SubListB s s')
-                       (() :: Constraint)
-                       (NotASubListOf s s')
-
-type family SubListB (s :: [*]) (s' :: [*]) :: Bool where
-  SubListB '[] s'      = 'True
-  SubListB (a ': as) s = (ElemB a s) && (SubListB as s)
-
-class ElementNotFound a s
-
--- type Elem a s = DropFalseErr (ElemB a s) (ElementNotFound a s)
-type Elem a s = If (ElemB a s)
-                   (() :: Constraint)
-                   (ElementNotFound a s)
-
-type family ElemB (a :: *) (s :: [*]) :: Bool where
-  ElemB a '[]       = 'False
-  ElemB a (a ': as) = 'True
-  ElemB a (b ': bs) = ElemB a bs
-
-type family AllSatisfy (const :: k -> Constraint) (s :: [k]) :: Constraint where
-  AllSatisfy c '[]       = ()
-  AllSatisfy c (a ': as) = (c a, AllSatisfy c as)
-
 -- | `restrict` in right-fixable style.
-(@>) :: Typeable a => (a -> b) -> (Union (s :\ a) -> b) -> Union s -> b
+(@>) :: Typeable a
+     => (a -> b)
+     -> (Union (Delete a s) -> b)
+     -> Union s
+     -> b
 r @> l = either l r . restrict
 infixr 2 @>
 {-# INLINE (@>) #-}
 
+-- | `restrict` in right-fixable style with existance restriction.
 (@!>) :: (Typeable a, Elem a s)
       => (a -> b)
-      -> (Union (s :\ a) -> b)
-      -> Union s -> b
+      -> (Union (Delete a s) -> b)
+      -> Union s
+      -> b
 r @!> l = either l r . restrict
 infixr 2 @!>
+{-# INLINE (@!>) #-}
 
-liftUnion :: (Typeable a, '[a] :< s) => a -> Union s
+liftUnion :: (Typeable a, Elem a s) => a -> Union s
 liftUnion = Union . toDyn
 {-# INLINE liftUnion #-}
 
 -- | Narrow down a @Union@.
-restrict :: Typeable a => Union s -> Either (Union (s :\ a)) a
+restrict :: Typeable a => Union s -> Either (Union (Delete a s)) a
 restrict (Union d) = maybe (Left $ Union d) Right $ fromDynamic d
 {-# INLINE restrict #-}
 
 -- | Generalize a @Union@.
-reUnion :: (s :< s') => Union s -> Union s'
+reUnion :: (SubList s s') => Union s -> Union s'
 reUnion (Union d) = Union d
 {-# INLINE reUnion #-}
 

--- a/example.hs
+++ b/example.hs
@@ -17,3 +17,11 @@ main = do
     putStrLn $ showMyUnion $ liftUnion (4 :: Int)
     putStrLn $ showMyUnion $ liftUnion 'a'
     putStrLn $ showMyUnion $ liftUnion [(), ()]
+    let u1 = liftUnion (4  :: Int) :: MyUnion
+        u2 = liftUnion (10 :: Int) :: MyUnion
+        u3 = liftUnion 'a'         :: MyUnion
+    putStrLn $ show u1
+    putStrLn $ show u3
+    putStrLn $ show $ u1 == u1
+    putStrLn $ show $ u1 == u2
+    putStrLn $ show $ u1 == u3

--- a/example.hs
+++ b/example.hs
@@ -1,6 +1,22 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+
+import Control.Exception
 import Data.OpenUnion
+import Data.Typeable
+
+data Exc1 = Exc1
+            deriving (Eq, Ord, Show, Typeable)
+instance Exception Exc1
+
+data Exc2 = Exc2
+            deriving (Eq, Ord, Show, Typeable)
+instance Exception Exc2
+
+type ExcUnion = Union '[Exc1, Exc2]
+
+showException :: ExcUnion -> IO String
+showException = return . show
 
 type MyUnion = Union '[Char, Int, [()]]
 
@@ -25,3 +41,6 @@ main = do
     putStrLn $ show $ u1 == u1
     putStrLn $ show $ u1 == u2
     putStrLn $ show $ u1 == u3
+
+    print =<< catch (throwIO Exc1) showException
+    print =<< catch (throwIO Exc2) showException

--- a/open-union.cabal
+++ b/open-union.cabal
@@ -85,13 +85,15 @@ library
                   Data.OpenUnion
                   Data.OpenUnion.Internal
 
-    build-depends : base == 4.*
+    build-depends: base == 4.*
+                 , type-fun
 
 executable example
     hs-source-dirs:   .
     main-is: example.hs
     ghc-options: -Wall -O2
     build-depends : base == 4.*
+                  , type-fun
                   , open-union
 
 source-repository head


### PR DESCRIPTION
- added dependency on package `type-fun` which is a collection of usefull type families
- added instances for `Show`, `Eq`, `Ord`, `Exception` making `Union` much more usefull
- `IncoherentInstances` replaced with type families
  - `liftUnion (10 :: Int) :: Union '[]` is imposible now

Hello, here is some improvements! Would you merge them and release new version? If you dont agree with these changes please let me know.
