### PR TITLE
Add flattenUnion to flatten union type

### DIFF
--- a/Data/OpenUnion.hs
+++ b/Data/OpenUnion.hs
@@ -4,7 +4,6 @@ module Data.OpenUnion
     , (@>)
     , liftUnion
     , reUnion
-    , flatUnion
     , flattenUnion
     , restrict
     , typesExhausted

--- a/Data/OpenUnion.hs
+++ b/Data/OpenUnion.hs
@@ -4,6 +4,7 @@ module Data.OpenUnion
     , (@>)
     , liftUnion
     , reUnion
+    , flatUnion
     , restrict
     , typesExhausted
     ) where

--- a/Data/OpenUnion.hs
+++ b/Data/OpenUnion.hs
@@ -5,6 +5,7 @@ module Data.OpenUnion
     , liftUnion
     , reUnion
     , flatUnion
+    , flattenUnion
     , restrict
     , typesExhausted
     ) where

--- a/Data/OpenUnion/Internal.hs
+++ b/Data/OpenUnion/Internal.hs
@@ -19,6 +19,7 @@ module Data.OpenUnion.Internal
     , liftUnion
     , reUnion
     , flatUnion
+    , flattenUnion
     , restrict
     , typesExhausted
     ) where
@@ -98,6 +99,12 @@ instance ( Exception e, Typeable e, Typeable es, Typeable e1
           sub = fromException some
       in fmap reUnion sub
 
+
+type family FlatElems a :: [*] where
+  FlatElems '[]              = '[]
+  FlatElems ((Union s) : ss) = s :++: FlatElems ss
+  FlatElems (x : s)          = x : FlatElems s
+
 -- general note: try to keep from re-constructing Unions if an existing one
 -- can just be type-coerced.
 
@@ -139,6 +146,11 @@ reUnion (Union d) = Union d
 flatUnion :: Union (Union s : a) -> Union (s :++: a)
 flatUnion (Union d) = Union d
 {-# INLINE flatUnion #-}
+
+-- | Flatten a @Union@.
+flattenUnion :: Union s -> Union (FlatElems s)
+flattenUnion (Union d) = Union d
+{-# INLINE flattenUnion #-}
 
 -- | Use this in places where all the @Union@ed options have been exhausted.
 typesExhausted :: Union '[] -> a

--- a/Data/OpenUnion/Internal.hs
+++ b/Data/OpenUnion/Internal.hs
@@ -18,7 +18,6 @@ module Data.OpenUnion.Internal
     , (@!>)
     , liftUnion
     , reUnion
-    , flatUnion
     , flattenUnion
     , restrict
     , typesExhausted
@@ -141,11 +140,6 @@ restrict (Union d) = maybe (Left $ Union d) Right $ fromDynamic d
 reUnion :: (SubList s s') => Union s -> Union s'
 reUnion (Union d) = Union d
 {-# INLINE reUnion #-}
-
--- | Flat a @Union@.
-flatUnion :: Union (Union s : a) -> Union (s :++: a)
-flatUnion (Union d) = Union d
-{-# INLINE flatUnion #-}
 
 -- | Flatten a @Union@.
 flattenUnion :: Union s -> Union (FlatElems s)

--- a/Data/OpenUnion/Internal.hs
+++ b/Data/OpenUnion/Internal.hs
@@ -18,13 +18,14 @@ module Data.OpenUnion.Internal
     , (@!>)
     , liftUnion
     , reUnion
+    , flatUnion
     , restrict
     , typesExhausted
     ) where
 
 import Control.Exception
 import Data.Dynamic
-import TypeFun.Data.List (SubList, Elem, Delete)
+import TypeFun.Data.List (SubList, Elem, Delete, (:++:))
 #if MIN_VERSION_base(4,10,0)
 import Data.Proxy
 import Data.Typeable
@@ -133,6 +134,11 @@ restrict (Union d) = maybe (Left $ Union d) Right $ fromDynamic d
 reUnion :: (SubList s s') => Union s -> Union s'
 reUnion (Union d) = Union d
 {-# INLINE reUnion #-}
+
+-- | Flat a @Union@.
+flatUnion :: Union (Union s : a) -> Union (s :++: a)
+flatUnion (Union d) = Union d
+{-# INLINE flatUnion #-}
 
 -- | Use this in places where all the @Union@ed options have been exhausted.
 typesExhausted :: Union '[] -> a


### PR DESCRIPTION
Thank you for your wonderful project! 

I added `flattenUnion` function to flatten nested union type.
The function allows library users to write like the following.

```hs
let a :: Union '[Union '[Char, Int], String, Union '[(), Double]]
    a = liftUnion "my string"

    a' :: Union '[Char, Int, String, (), Double]
    a' = flattenUnion a
```

In this case, it converts `Union '[Union '[Char, Int], String, Union '[(), Double]]` to `Union '[Char, Int, String, (), Double]`.

