### PR TITLE
Highlight Haskell code and add a title in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,30 @@
+# open-union
+
 ## Intro
 
 open-union adds type-safe extensible unions to Haskell, which can be used a la:
 
-    {-# LANGUAGE TypeOperators #-}
-    {-# LANGUAGE ScopedTypeVariables #-}
-    import Data.OpenUnion
+```hs
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+import Data.OpenUnion
 
-    type MyUnion = Union (Char :| Int :| [()])
+type MyUnion = Union (Char :| Int :| [()])
 
-    showMyUnion :: MyUnion -> String
-    showMyUnion
-        =  (\(c :: Char) -> "char: " ++ show c)
-        @> (\(i :: Int) -> "int: " ++ show i)
-        @> (\(l :: [()]) -> "list length: " ++ show (length l))
-        @> (\(s :: String) -> "string: " ++ s)
-        @> typesExhausted
+showMyUnion :: MyUnion -> String
+showMyUnion
+    =  (\(c :: Char) -> "char: " ++ show c)
+    @> (\(i :: Int) -> "int: " ++ show i)
+    @> (\(l :: [()]) -> "list length: " ++ show (length l))
+    @> (\(s :: String) -> "string: " ++ s)
+    @> typesExhausted
 
-    main :: IO ()
-    main = do
-        putStrLn $ showMyUnion $ liftUnion (4 :: Int)
-        putStrLn $ showMyUnion $ liftUnion 'a'
-        putStrLn $ showMyUnion $ liftUnion [(), ()]
+main :: IO ()
+main = do
+    putStrLn $ showMyUnion $ liftUnion (4 :: Int)
+    putStrLn $ showMyUnion $ liftUnion 'a'
+    putStrLn $ showMyUnion $ liftUnion [(), ()]
+```
 
 which prints:
 
@@ -30,11 +34,13 @@ which prints:
 
 The original use case for this library was code like this (snipped from some record/playback logic):
 
-    type TrackStates = '[Stopped, Recording, Playing]
+```hs
+type TrackStates = '[Stopped, Recording, Playing]
 
-    startRecording
-      :: Union (TrackStates :\ Recording)
-      -> ([Note], Union '[Recording])
+startRecording
+    :: Union (TrackStates :\ Recording)
+    -> ([Note], Union '[Recording])
+```
 
 The `(:\)` type-level operator is for removal from a set, i.e. `startRecording` can be
 applied to a track in any state except the `Recording` state.


### PR DESCRIPTION
I just hightlighted codes in `README.md` and added a title on the top of `README.md`.
Hightlighting is more readable for users. I think many repositories have a title, so I added one.

Here is preview of `README.md`:
<https://github.com/nwtgck/open-union/tree/96f3204fb917ad34a54c7db31c32637981038f16>

You may not like this style. If don't like this, don't merge or merge a part of one :D
